### PR TITLE
Update OCI plugin dependency version to `0.11.0`

### DIFF
--- a/mod.sp
+++ b/mod.sp
@@ -16,7 +16,7 @@ mod "oci_insights" {
   require {
     steampipe = "0.13.1"
     plugin "oci" {
-      version = "0.9.0"
+      version = "0.11.0"
     }
   }
 }


### PR DESCRIPTION
### Checklist
- [ ] Issue(s) linked
